### PR TITLE
updated gemfile for heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,13 +142,19 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     msgpack (1.5.1)
     multipart-post (2.1.1)
     naught (1.1.0)
     netrc (0.11.0)
     nio4r (2.5.8)
+    nokogiri (1.13.6)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.6-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.6-x86_64-linux)
       racc (~> 1.4)
     public_suffix (4.0.7)
     puma (5.6.4)
@@ -269,6 +275,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
+  x86_64-linux
 
 DEPENDENCIES
   autoprefixer-rails (= 10.2.5)


### PR DESCRIPTION
added 

bundle lock --add-platform ruby
bundle lock --add-platform x86_64-linux

to allow pushing to heroku after this error:

Bundler Output: Your bundle only supports platforms ["arm64-darwin-21"] but your local platform is x86_64-linux. Add the current platform to the lockfile with `bundle lock --add-platform x86_64-linux` and try again.